### PR TITLE
Adjust Node Size

### DIFF
--- a/app/main_window/graph/__init__.py
+++ b/app/main_window/graph/__init__.py
@@ -1,10 +1,14 @@
 from PyQt5.QtWidgets import QGraphicsView, QGraphicsScene, QGraphicsObject, \
     QWidget, QVBoxLayout
 from PyQt5.QtCore import Qt, QRectF, QPointF, pyqtSignal
-from PyQt5.QtGui import QColor, QPen, QBrush, QFont, QPainter
+from PyQt5.QtGui import QColor, QPen, QBrush, QFont, QPainter, QFont, QFontMetrics
 from ...data.tree import Status, Node
 from ...settings import settings_manager
 from app import settings
+
+TEXT_BONDER_DISTANCE_WIDTH = 10
+TEXT_BONDER_DISTANCE_HEIGHT = 3
+
 
 class GraphicsNodeItem(QGraphicsObject):
     request_relayout = pyqtSignal()
@@ -24,18 +28,19 @@ class GraphicsNodeItem(QGraphicsObject):
         self.rect_pen = QPen(settings_manager.get("graph/rectColor", type=QColor), settings_manager.get("graph/rectPenWidth", type=float))
         self.line_pen = QPen(settings_manager.get("graph/lineColor", type=QColor), settings_manager.get("graph/linePenWidth", type=float))
         self.text_pen = QPen(settings_manager.get("graph/textColor", type=QColor), settings_manager.get("graph/textPenWidth", type=float))
+        self.fixed_nodewidth, self.fixed_nodeheight = _calculate_node_boundary(self.data_node.name) 
 
     def boundingRect(self) -> QRectF:
-        NODE_WIDTH = settings_manager.get("graph/nodeWidth", type=float)
-        NODE_HEIGHT = settings_manager.get("graph/nodeHeight", type=float)
+        # NODE_WIDTH = settings_manager.get("graph/nodeWidth", type=float)
+        # NODE_HEIGHT = settings_manager.get("graph/nodeHeight", type=float)
         H_SPACING = settings_manager.get("graph/nodeHSpacing", type=float)
         V_SPACING = settings_manager.get("graph/nodeVSpacing", type=float)
         return QRectF(-self.depth * H_SPACING, -V_SPACING,
-                      self.depth * H_SPACING + NODE_WIDTH, V_SPACING + NODE_HEIGHT)
+                      self.depth * H_SPACING + self.fixed_nodewidth, V_SPACING + self.fixed_nodeheight)
 
     def paint(self, painter, option, widget=None):
-        NODE_WIDTH = settings_manager.get("graph/nodeWidth", type=float)
-        NODE_HEIGHT = settings_manager.get("graph/nodeHeight", type=float)
+        # NODE_WIDTH = settings_manager.get("graph/nodeWidth", type=float)
+        # NODE_HEIGHT = settings_manager.get("graph/nodeHeight", type=float)
         H_SPACING = settings_manager.get("graph/nodeHSpacing", type=float)
         V_SPACING = settings_manager.get("graph/nodeVSpacing", type=float)
         FONT_SIZE = settings_manager.get("graph/fontSize", type=int)
@@ -51,20 +56,20 @@ class GraphicsNodeItem(QGraphicsObject):
             if status == 0:
                 continue
             elif status == 1:
-                painter.drawLine(QPointF(x, -V_SPACING), QPointF(x, NODE_HEIGHT))
+                painter.drawLine(QPointF(x, -V_SPACING), QPointF(x, self.fixed_nodeheight))
             elif status == 2:
-                painter.drawLine(QPointF(x, -V_SPACING), QPointF(x, NODE_HEIGHT / 2))
+                painter.drawLine(QPointF(x, -V_SPACING), QPointF(x, self.fixed_nodeheight / 2))
 
         if self.depth > 0:
             elbow_x = -H_SPACING + H_SPACING / 2
-            elbow_y = NODE_HEIGHT / 2
+            elbow_y = self.fixed_nodeheight / 2
             painter.drawLine(QPointF(elbow_x, elbow_y), QPointF(0, elbow_y)) 
 
         # node rect
         painter.save()
         bg_color = self.colors.get(self.data_node.status, QColor(Qt.lightGray))
         painter.setBrush(QBrush(bg_color)); painter.setPen(self.rect_pen)
-        node_rect = QRectF(0, 0, NODE_WIDTH, NODE_HEIGHT)
+        node_rect = QRectF(0, 0, self.fixed_nodewidth, self.fixed_nodeheight)
         painter.drawRoundedRect(node_rect, 5, 5)
         painter.setPen(self.text_pen); painter.setFont(self.font)
         text_rect = node_rect.adjusted(10, 5, -10, -5)
@@ -119,7 +124,7 @@ class TreeGraphWidget(QWidget):
     def relayout_tree(self):
         H_SPACING = settings_manager.get("graph/nodeHSpacing", type=float)
         V_SPACING = settings_manager.get("graph/nodeVSpacing", type=float)
-        NODE_HEIGHT = settings_manager.get("graph/nodeHeight", type=float)
+        # NODE_HEIGHT = settings_manager.get("graph/nodeHeight", type=float)
         self.scene.clear()
 
         y_cursor = 0 # shared across all recursive calls
@@ -132,6 +137,8 @@ class TreeGraphWidget(QWidget):
             """
             nonlocal y_cursor
 
+            _,fixed_nodeheight = _calculate_node_boundary(node.name)
+
             x_pos = depth * H_SPACING
             y_pos = y_cursor
             is_expanded = self.expand_status.get(node.identity, None)
@@ -142,7 +149,7 @@ class TreeGraphWidget(QWidget):
             self.init_item(item)
             self.scene.addItem(item)
             item.setPos(x_pos, y_pos)
-            y_cursor += NODE_HEIGHT + V_SPACING
+            y_cursor += fixed_nodeheight + V_SPACING
 
             if is_expanded and node.children:
                 # recusively layout the children
@@ -205,3 +212,16 @@ class TreeGraphWidget(QWidget):
         
         self.complete_current()
         self.complete_current()
+
+def _calculate_node_boundary(text: str) -> tuple[float,float] :
+    """calculate a node's width and height according to its text"""
+    # According to text, adjust node_length
+    FONT_OBJECT = QFont(settings_manager.get("graph/fontFamily", type=str), settings_manager.get("graph/fontSize", type=int))
+    # build QfontMetrics Objext, compute NodeWidth
+    METRICS = QFontMetrics(FONT_OBJECT)
+    fixed_nodewidth = max(settings_manager.get("graph/MinNodeWidth", type=float),
+            METRICS.horizontalAdvance(text+'[+]') + 2*TEXT_BONDER_DISTANCE_WIDTH)
+    fixed_nodeheight = max(settings_manager.get("graph/MinNodeHeight", type=float),
+            METRICS.height() + 2*TEXT_BONDER_DISTANCE_HEIGHT,
+        )
+    return (fixed_nodewidth, fixed_nodeheight)

--- a/app/settings.py
+++ b/app/settings.py
@@ -7,8 +7,8 @@ logger = logging.getLogger(__name__)
 DEFAULT_SETTINGS = {
     "hotkey/mainWindowHotkey": QKeySequence(Qt.CTRL + Qt.Key_B).toString(),
     
-    "graph/nodeWidth": 80,
-    "graph/nodeHeight": 18,
+    "graph/MinNodeWidth": 80,
+    "graph/MinNodeHeight": 18,
     "graph/nodeHSpacing": 25,
     "graph/nodeVSpacing": 15,
     "graph/fontSize": 10,


### PR DESCRIPTION
in graph/__init__.py, added function: _calculate_node_boundary() . Tree Node will adjust its Height and Width according to text's lenth, fontSize and fontFamily. Also, edited settings.py, change 'NodeWidth' to 'MinNodeWidth' and 'NodeHeight' to 'MinNodeHeight'